### PR TITLE
Fix consistency and Schema Property Creation Error in Python Examples

### DIFF
--- a/bike-tutorial/python/bike-tutorial.py
+++ b/bike-tutorial/python/bike-tutorial.py
@@ -1,6 +1,5 @@
 import woqlclient.woqlClient as woql
 from woqlclient import WOQLQuery
-import json
 from csvs import csvs
 
 server_url = "http://localhost:6363"
@@ -14,17 +13,19 @@ def create_schema(client):
         client : a WOQLClient() connection
 
     """
-    station = WOQLQuery().doctype("Station").label("Bike Station")
-    station.description("A station where bikes are deposited")
-    bicycle = WOQLQuery().doctype("Bicycle").label("Bicycle")
-    journey = WOQLQuery().doctype("Journey").label("Journey")
-    journey.property("start_station", "Station").label("Start Station")
-    journey.property("end_station", "Station").label("End Station")
-    journey.property("duration", "integer").label("Journey Duration")
-    journey.property("start_time", "dateTime").label("Time Started")
-    journey.property("end_time", "dateTime").label("Time Ended")
-    journey.property("journey_bicycle", "Bicycle").label("Bicycle Used")
-    schema = WOQLQuery().when(True).woql_and(station, bicycle, journey)
+    schema = WOQLQuery().when(True).woql_and(
+        WOQLQuery().doctype("Station").
+            label("Bike Station").
+            description("A station where bikes are deposited"),
+        WOQLQuery().doctype("Bicycle").label("Bicycle"),
+        WOQLQuery().doctype("Journey").label("Journey").
+            property("start_station", "Station").label("Start Station").
+            property("end_station", "Station").label("End Station").
+            property("duration", "integer").label("Journey Duration").
+            property("start_time", "dateTime").label("Time Started").
+            property("end_time", "dateTime").label("Time Ended").
+            property("journey_bicycle", "Bicycle").label("Bicycle Used")
+    )
     return schema.execute(client)
 
 
@@ -49,41 +50,46 @@ def get_csv_variables(url):
     return csv
 
 
-wrangles = [
-    WOQLQuery().idgen("doc:Journey", [
-        "v:Start_ID", "v:Start_Time", "v:Bike"], "v:Journey_ID"),
-    WOQLQuery().idgen("doc:Station", [
-        "v:Start_ID"], "v:Start_Station_URL"),
-    WOQLQuery().cast("v:Duration", "xsd:integer", "v:Duration_Cast"),
-    WOQLQuery().cast("v:Bike", "xsd:string", "v:Bike_Label"),
-    WOQLQuery().cast("v:Start_Time", "xsd:dateTime", "v:Start_Time_Cast"),
-    WOQLQuery().cast("v:End_Time", "xsd:dateTime", "v:End_Time_Cast"),
-    WOQLQuery().cast("v:Start_Station", "xsd:string", "v:Start_Station_Label"),
-    WOQLQuery().cast("v:End_Station", "xsd:string", "v:End_Station_Label"),
-    WOQLQuery().idgen("doc:Station", ["v:End_ID"], "v:End_Station_URL"),
-    WOQLQuery().idgen("doc:Bicycle", ["v:Bike_Label"], "v:Bike_URL"),
-    WOQLQuery().concat("Journey from v:Start_ID to v:End_ID at v:Start_Time", "v:Journey_Label"),
-    WOQLQuery().concat("Bike v:Bike from v:Start_Station to v:End_Station at v:Start_Time until v:End_Time",
-                       "v:Journey_Description")
-]
+def get_wrangles():
+    wrangles = [
+        WOQLQuery().idgen("doc:Journey", [
+            "v:Start_ID", "v:Start_Time", "v:Bike"], "v:Journey_ID"),
+        WOQLQuery().idgen("doc:Station", [
+            "v:Start_ID"], "v:Start_Station_URL"),
+        WOQLQuery().cast("v:Duration", "xsd:integer", "v:Duration_Cast"),
+        WOQLQuery().cast("v:Bike", "xsd:string", "v:Bike_Label"),
+        WOQLQuery().cast("v:Start_Time", "xsd:dateTime", "v:Start_Time_Cast"),
+        WOQLQuery().cast("v:End_Time", "xsd:dateTime", "v:End_Time_Cast"),
+        WOQLQuery().cast("v:Start_Station", "xsd:string", "v:Start_Station_Label"),
+        WOQLQuery().cast("v:End_Station", "xsd:string", "v:End_Station_Label"),
+        WOQLQuery().idgen("doc:Station", ["v:End_ID"], "v:End_Station_URL"),
+        WOQLQuery().idgen("doc:Bicycle", ["v:Bike_Label"], "v:Bike_URL"),
+        WOQLQuery().concat("Journey from v:Start_ID to v:End_ID at v:Start_Time", "v:Journey_Label"),
+        WOQLQuery().concat("Bike v:Bike from v:Start_Station to v:End_Station at v:Start_Time until v:End_Time",
+                           "v:Journey_Description")
+    ]
+    return wrangles
 
-inserts = WOQLQuery().woql_and(
-    WOQLQuery().insert("v:Journey_ID", "Journey").
-        label("v:Journey_Label").
-        description("v:Journey_Description").
-        property("start_time", "v:Start_Time_Cast").
-        property("end_time", "v:End_Time_Cast").
-        property("duration", "v:Duration_Cast").
-        property("start_station", "v:Start_Station_URL").
-        property("end_station", "v:End_Station_URL").
-        property("journey_bicycle", "v:Bike_URL"),
-    WOQLQuery().insert("v:Start_Station_URL", "Station").
-        label("v:Start_Station_Label"),
-    WOQLQuery().insert("v:End_Station_URL", "Station").
-        label("v:End_Station_Label"),
-    WOQLQuery().insert("v:Bike_URL", "Bicycle").
-        label("v:Bike_Label")
-)
+
+def get_inserts():
+    inserts = WOQLQuery().woql_and(
+        WOQLQuery().insert("v:Journey_ID", "Journey").
+            label("v:Journey_Label").
+            description("v:Journey_Description").
+            property("start_time", "v:Start_Time_Cast").
+            property("end_time", "v:End_Time_Cast").
+            property("duration", "v:Duration_Cast").
+            property("start_station", "v:Start_Station_URL").
+            property("end_station", "v:End_Station_URL").
+            property("journey_bicycle", "v:Bike_URL"),
+        WOQLQuery().insert("v:Start_Station_URL", "Station").
+            label("v:Start_Station_Label"),
+        WOQLQuery().insert("v:End_Station_URL", "Station").
+            label("v:End_Station_Label"),
+        WOQLQuery().insert("v:Bike_URL", "Bicycle").
+            label("v:Bike_Label")
+    )
+    return inserts
 
 
 def load_csvs(client, csvlist, wrangl, insert):
@@ -100,8 +106,9 @@ def load_csvs(client, csvlist, wrangl, insert):
         answer.execute(client)
 
 
-client = woql.WOQLClient()
-client.connect(server_url, key)
-client.createDatabase(dbId, "Bicycle Graph")
-create_schema(client)
-load_csvs(client, csvs, wrangles, inserts)
+if __name__ == "__main__":
+    client = woql.WOQLClient()
+    client.connect(server_url, key)
+    client.createDatabase(dbId, "Bicycle Graph")
+    create_schema(client)
+    load_csvs(client, csvs, get_wrangles(), get_inserts())

--- a/politics-tutorial/python/dublin-council.py
+++ b/politics-tutorial/python/dublin-council.py
@@ -1,13 +1,13 @@
 import woqlclient.woqlClient as woql
 from woqlclient import WOQLQuery
-import json
 
-CSVS = {"OverallSimilarity" : "https://terminusdb.com/t/data/council/weighted_similarity.csv"}
+CSVS = {"OverallSimilarity": "https://terminusdb.com/t/data/council/weighted_similarity.csv"}
 
 server_url = "http://localhost:6363"
-dbId= "mydb"
+dbId = "mydb"
 key = "root"
 dburl = server_url + "/mydb"
+
 
 def create_schema(client):
     """The query which creates the schema
@@ -33,7 +33,8 @@ def create_schema(client):
         )
     return schema.execute(client)
 
-def get_inserts(relation):
+
+def get_inserts():
     inserts = WOQLQuery().woql_and(
         WOQLQuery().insert("v:Party_A_ID", "Party").label("v:Party_A"),
         WOQLQuery().insert("v:Party_B_ID", "Party").label("v:Party_B"),
@@ -48,6 +49,7 @@ def get_inserts(relation):
       )
     return inserts
 
+
 def get_csv_variables(url):
     """Extracting the data from a CSV and binding it to variables
        Parameters
@@ -56,7 +58,7 @@ def get_csv_variables(url):
        url : string, the URL of the CSV
        """
     csv = WOQLQuery().get(
-        WOQLQuery().woql_as("councillor_a","v:Rep_A").
+        WOQLQuery().woql_as("councillor_a", "v:Rep_A").
                     woql_as("councillor_b", "v:Rep_B").
                     woql_as("party_a", "v:Party_A").
                     woql_as("party_b", "v:Party_B").
@@ -64,7 +66,8 @@ def get_csv_variables(url):
         ).remote(url)
     return csv
 
-def get_wrangles(relation):
+
+def get_wrangles():
     wrangles = [
          WOQLQuery().idgen("doc:Party", ["v:Party_A"], "v:Party_A_ID"),
          WOQLQuery().idgen("doc:Party", ["v:Party_B"], "v:Party_B_ID"),
@@ -75,6 +78,7 @@ def get_wrangles(relation):
          WOQLQuery().concat("v:Rep_A similarity v:Distance to v:Rep_B", "v:Rel_Label")
     ]
     return wrangles
+
 
 def load_csvs(client, csvs):
     """Load the CSVs as input
@@ -91,9 +95,11 @@ def load_csvs(client, csvs):
         answer = WOQLQuery().when(inputs, inserts)
         answer.execute(client)
 
-# run tutorial
-client = woql.WOQLClient()
-client.connect(server_url, key)
-client.createDatabase(dbId, "Dublin Council Graph")
-create_schema(client)
-load_csvs(client, CSVS)
+
+if __name__ == "__main__": 
+    # run tutorial
+    client = woql.WOQLClient()
+    client.connect(server_url, key)
+    client.createDatabase(dbId, "Dublin Council Graph")
+    create_schema(client)
+    load_csvs(client, CSVS)

--- a/politics-tutorial/python/dublin-council.py
+++ b/politics-tutorial/python/dublin-council.py
@@ -89,9 +89,9 @@ def load_csvs(client, csvs):
     """
     for key, url in csvs.items():
         csv = get_csv_variables(url)
-        wrangles = get_wrangles(key)
+        wrangles = get_wrangles()
         inputs = WOQLQuery().woql_and(csv, *wrangles)
-        inserts = get_inserts(key)
+        inserts = get_inserts()
         answer = WOQLQuery().when(inputs, inserts)
         answer.execute(client)
 


### PR DESCRIPTION
#### What is the purpose of this PR?
The current bike share Python example as per cfb598bbe198818abb4d0abed7cf8632eac2b431 doesn't create properties correctly in the schema - possibly something was broken in the various edits over the last week? In any case, I made some minor changes to the schema query format in the `create_schema` function to make it more consistent with the Dublin politics example as well as the JavaScript examples. In addition, there are also minor cleanups such as removing unnecessary function arguments and imports in either script. Hope this is okay, and thanks for posting these examples! 